### PR TITLE
Bump asn1lib

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  asn1lib: '^0.5.14'
+  asn1lib: ^0.6.4
   pointycastle: '^1.0.2'
   tuple: '^1.0.1'
 


### PR DESCRIPTION
Doesn't cause any problems, but this way I can use ssh_key with [steel_crypt](https://pub.dev/packages/steel_crypt) without any package conflicts.